### PR TITLE
Add basic CMake configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 bin/
 # Ignore the GNU idutils ID file.
 ID
+# Ignore common CMake build directory
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,17 @@
+
+cmake_minimum_required(VERSION 2.8)
+
+project(text_view CXX)
+
+if(CMAKE_COMPILER_IS_GNUCXX)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -fconcepts")
+endif()
+
+find_path(CMCSTL2_INCLUDE_DIR "experimental/ranges/concepts")
+
+include_directories(include)
+include_directories(${CMCSTL2_INCLUDE_DIR})
+
+add_subdirectory(examples)
+add_subdirectory(test)
+

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ based character encoding and code point enumeration library.
     (#building-and-installing-cmcstl2)
   - [Building and installing Text_view]
     (#building-and-installing-text_view)
+  - [Building and installing Text_view with CMake]
+    (#building-and-installing-text_view-with-cmake)
 - [Usage](#usage)
   - [Header &lt;experimental/text_view&gt; synopsis]
     (#header-experimentaltext_view-synopsis)
@@ -201,6 +203,26 @@ $ make
 
 If the build succeeds, a few test and utility programs will be present in the
 `bin` directory.
+
+## Building and installing [Text_view] with [CMake]
+Alternatively, [CMake] may be used to build the [Text_view] tests and examples.
+
+To do so, you must pass the paths to [GCC] and [cmcstl2] to `cmake` via
+the `CMAKE_CXX_COMPILER` and `CMCSTL2_INCLUDE_DIR` configuration variables
+respectively. For example
+
+```sh
+$ mkdir build
+$ cd build
+$ cmake .. -DCMAKE_CXX_COMPILER=/path/to/g++-6.2 -DCMCSTL2_INCLUDE_DIR=/path/to/cmcstl2/include
+$ cmake --build .
+```
+
+(There are other ways to pass these paths to CMake, for example via
+environment variables -- see the [CMake] documentation for details.)
+
+If the build succeeds, test and utility programs will be present in the
+`test` and `examples` subdirectories of the build directory.
 
 # Usage
 [Text_view] is currently a header-only library.  To use it in your own code,
@@ -2757,6 +2779,8 @@ encodings such as [Windows code page 1252].
   http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2249.html
 - [Unicode]  
   http://unicode.org
+- [CMake]  
+  https://cmake.org
 
 [Text_view]:
 https://github.com/tahonermann/text_view
@@ -2809,3 +2833,6 @@ http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0252r0.pdf
 [gcc]:
 https://gcc.gnu.org
 (GCC, the GNU Compiler Collection)
+[cmake]:
+https://cmake.org
+(The CMake build system)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,7 @@
+
+add_executable(tv-dump tv_dump.cpp)
+
+add_executable(tv-enumerate-utf8-code-points tv_enumerate_utf8_code_points.cpp)
+
+add_executable(tv-find-utf8-multi-code-unit-code-point
+               tv_find_utf8_multi_code_unit_code_point.cpp)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+
+add_executable(test-text-view test-text_view.cpp)
+


### PR DESCRIPTION

CMake is more-or-less the de-facto standard build system for C++ today. This PR adds a very basic CMake configuration which is sufficient to build the tests and examples, and to use CLion to hack on Text_view.

The configure step requires the compiler to be set to GCC 6.2 (via the `CMAKE_CXX_COMPILER` switch), and the path to the STL2 headers to be supplied via the `CMCSTL2_INCLUDE_DIR` variable if these are not present in one of the default search paths (i.e. `/usr/include` or `/usr/local/include`). For example, on my system, I use the following build commands:

```sh
$ mkdir build
$ cd build
$ cmake .. -DCMAKE_CXX_COMPILER=g++-6 -DCMCSTL2_INCLUDE_DIR=/Users/tristan/Coding/cmcstl2/include
$ cmake --build .
```

The second commit also adds instructions to README.md.
