### PR TITLE
otext_iterator updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ bin/
 ID
 # Ignore common CMake build directory
 build/
+.vscode/

--- a/include/text_view_detail/otext_iterator.hpp
+++ b/include/text_view_detail/otext_iterator.hpp
@@ -22,9 +22,6 @@ inline namespace text {
 namespace text_detail {
 
 template<TextEncoding ET, CodeUnitOutputIterator<code_unit_type_t<ET>> CUIT>
-class otext_iterator_mixin;
-
-template<TextEncoding ET, CodeUnitOutputIterator<code_unit_type_t<ET>> CUIT>
 class otext_cursor
     : private subobject<typename ET::state_type>
 {
@@ -35,7 +32,36 @@ class otext_cursor
     using state_transition_type = typename ET::state_transition_type;
 
 public:
-    using mixin = otext_iterator_mixin<ET, CUIT>;
+    using difference_type = ranges::difference_type_t<iterator_type>;
+
+    class mixin
+        : protected ranges::basic_mixin<otext_cursor>
+    {
+        using base_type = ranges::basic_mixin<otext_cursor>;
+    public:
+        using encoding_type = typename otext_cursor::encoding_type;
+        using state_type = typename otext_cursor::state_type;
+        using state_transition_type = typename otext_cursor::state_transition_type;
+
+        mixin() = default;
+
+        mixin(
+            state_type state,
+            iterator_type current)
+        :
+            base_type{otext_cursor{std::move(state), std::move(current)}}
+        {}
+
+        using base_type::base_type;
+
+        const state_type& state() const noexcept {
+            return this->get().state();
+        }
+
+        const iterator_type& base() const noexcept {
+            return this->get().current;
+        }
+    };
 
     otext_cursor() = default;
 
@@ -52,13 +78,6 @@ public:
     }
     state_type& state() noexcept {
         return base_type::get();
-    }
-
-    const iterator_type& base() const noexcept {
-        return current;
-    }
-    iterator_type& base() noexcept {
-        return current;
     }
 
     void write(const state_transition_type &stt) {
@@ -105,40 +124,6 @@ public:
 
 private:
     iterator_type current;
-};
-
-
-template<TextEncoding ET, CodeUnitOutputIterator<code_unit_type_t<ET>> CUIT>
-class otext_iterator_mixin
-    : protected ranges::basic_mixin<otext_cursor<ET, CUIT>>
-{
-    using iterator_type = CUIT;
-    using cursor_type = otext_cursor<ET, CUIT>;
-    using base_type = ranges::basic_mixin<cursor_type>;
-
-public:
-    using encoding_type = ET;
-    using state_type = typename ET::state_type;
-    using state_transition_type = typename ET::state_transition_type;
-
-    otext_iterator_mixin() = default;
-
-    otext_iterator_mixin(
-        state_type state,
-        iterator_type current)
-    :
-        base_type{cursor_type{std::move(state), std::move(current)}}
-    {}
-
-    using base_type::base_type;
-
-    const state_type& state() const noexcept {
-        return this->get().state();
-    }
-
-    const iterator_type& base() const noexcept {
-        return this->get().base();
-    }
 };
 
 } // namespace text_detail

--- a/include/text_view_detail/otext_iterator.hpp
+++ b/include/text_view_detail/otext_iterator.hpp
@@ -76,6 +76,33 @@ public:
         current = tmp;
     }
 
+    void next() noexcept
+    {}
+
+    auto post_increment() noexcept {
+        class proxy
+        {
+        public:
+            proxy(otext_cursor& self) noexcept
+                : self_(self)
+            {}
+            proxy& operator*() noexcept {
+                return *this;
+            }
+            proxy& operator=(const state_transition_type &stt) {
+                self_.write(stt);
+                return *this;
+            }
+            proxy& operator=(const character_type_t<encoding_type> &value) {
+                self_.write(value);
+                return *this;
+            }
+        private:
+            otext_cursor& self_;
+        };
+        return proxy{*this};
+    }
+
 private:
     iterator_type current;
 };


### PR DESCRIPTION
Two separate commits:

1. Implement `post_increment` for `otext_cursor`, returning a proper proxy.
2. Nest `otext_cursor_mixin` into `otext_cursor` as `mixin`. (This is purely to simplify the presentation.)
